### PR TITLE
Fix Docker build network issues with DNS and retry logic

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -10,6 +10,9 @@ COPY frontend ./
 RUN npm run build
 
 FROM python:3.12-slim AS base
+
+# Set DNS servers to improve network connectivity
+RUN echo "nameserver 8.8.8.8\nnameserver 8.8.4.4" > /etc/resolv.conf
 FROM base AS backend-builder
 
 WORKDIR /app
@@ -20,11 +23,22 @@ ENV POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_CREATE=1 \
     POETRY_CACHE_DIR=/tmp/poetry_cache
 
-RUN python3 -m pip install poetry --break-system-packages
+# Install poetry with retries to handle network issues
+RUN for i in $(seq 1 3); do \
+        python3 -m pip install poetry --break-system-packages && break || \
+        echo "Retry $i: pip install failed, retrying in 5 seconds..." && \
+        sleep 5; \
+    done
 
 COPY pyproject.toml poetry.lock ./
 RUN touch README.md
-RUN export POETRY_CACHE_DIR && poetry install --no-root && rm -rf $POETRY_CACHE_DIR
+# Install dependencies with retries to handle network issues
+RUN export POETRY_CACHE_DIR && \
+    for i in $(seq 1 3); do \
+        poetry install --no-root && rm -rf $POETRY_CACHE_DIR && break || \
+        echo "Retry $i: poetry install failed, retrying in 5 seconds..." && \
+        sleep 5; \
+    done
 
 FROM base AS openhands-app
 


### PR DESCRIPTION
## Description
This PR addresses the network connectivity issues during Docker build for the multi-user support and webhook management UI feature. The build was failing due to network timeouts when trying to install dependencies.

## Changes Made
- Added DNS configuration to improve network connectivity in the Docker container
- Implemented retry logic for pip install and poetry install commands to handle temporary network issues
- Set Google DNS servers (8.8.8.8 and 8.8.4.4) to improve DNS resolution

## Testing
- These changes should improve the reliability of the Docker build process in environments with network connectivity issues

## Notes
- The retry logic will attempt to install dependencies up to 3 times with a 5-second delay between attempts
- This approach is more resilient to temporary network issues than the previous implementation

## Related Issues
- Fixes Docker build network connectivity issues for multi-user support and webhook management UI feature