### PR TITLE
Fix Account Settings buttons in profile page

### DIFF
--- a/frontend/src/routes/profile.tsx
+++ b/frontend/src/routes/profile.tsx
@@ -130,14 +130,14 @@ export default function Profile() {
               className="w-full justify-start"
               onClick={() => navigate("/settings/app")}
             >
-              {t(I18nKey.SETTINGS$APP_SETTINGS)}
+              {t(I18nKey.SETTINGS$NAV_APPLICATION)}
             </Button>
             <Button
               variant="outline"
               className="w-full justify-start"
-              onClick={() => navigate("/settings/webhooks")}
+              onClick={() => navigate("/settings/secrets")}
             >
-              {t(I18nKey.WEBHOOK$WEBHOOK_MANAGEMENT)}
+              {t(I18nKey.SETTINGS$NAV_SECRETS)}
             </Button>
           </CardContent>
         </Card>


### PR DESCRIPTION
🐛 Bug Fixes:
- Fix empty Application button by using correct translation key
- Remove redundant Webhook Management button (moved to main settings)
- Add missing Secrets button with proper navigation

🔧 Technical Changes:
- Updated profile.tsx to use SETTINGS$NAV_APPLICATION translation key
- Replaced webhook management button with secrets button
- Added navigation to /settings/secrets for secrets management

✅ Verified Working:
- Application button now shows proper text and navigates correctly
- Secrets button added and working with proper settings page
- Webhook management properly removed from profile (available in main settings)
- All Account Settings buttons now functional and properly labeled

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
