### PR TITLE
🎨 Fix webhook form scrolling and layout issues

### DIFF
--- a/frontend/src/components/features/settings/webhook-settings/webhook-form.tsx
+++ b/frontend/src/components/features/settings/webhook-settings/webhook-form.tsx
@@ -111,8 +111,8 @@ export function WebhookForm({ webhook, onClose }: WebhookFormProps) {
 
   return (
     <Dialog open={true} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-[500px]">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[500px] max-h-[90vh] flex flex-col">
+        <DialogHeader className="flex-shrink-0">
           <DialogTitle>
             {webhook
               ? t(I18nKey.WEBHOOK$EDIT_WEBHOOK)
@@ -124,7 +124,8 @@ export function WebhookForm({ webhook, onClose }: WebhookFormProps) {
         </DialogHeader>
 
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
+            <div className="flex-1 overflow-y-auto space-y-4 pr-2">
             <FormField
               control={form.control}
               name="name"
@@ -289,8 +290,9 @@ export function WebhookForm({ webhook, onClose }: WebhookFormProps) {
                 </FormItem>
               )}
             />
+            </div>
 
-            <DialogFooter>
+            <DialogFooter className="flex-shrink-0 mt-4">
               <Button
                 type="button"
                 variant="outline"


### PR DESCRIPTION
## 🐛 Problem
The webhook form dialog had several UI issues:
- Form content was too long and extended beyond viewport boundaries
- Top and bottom parts of the form were going behind header and footer
- No proper scrolling mechanism for long forms
- Users couldn't access all form fields or the submit button

## ✅ Solution
Implemented proper dialog layout with scrollable content:

### 🔧 Changes Made
- **Added max-height constraint**: Set `max-h-[90vh]` to prevent dialog from exceeding viewport height
- **Implemented flexbox layout**: Used `flex flex-col` for proper vertical layout structure
- **Created scrollable content area**: Added `overflow-y-auto` to form content with `flex-1` to take available space
- **Fixed header/footer positioning**: Made header and footer `flex-shrink-0` to keep them always visible
- **Added proper spacing**: Included `pr-2` for scrollbar space and `mt-4` for footer separation

### 🎨 Layout Structure
```
Dialog (max-h-90vh, flex-col)
├── Header (flex-shrink-0) - Always visible at top
├── Form Content (flex-1, overflow-y-auto) - Scrollable middle section
└── Footer (flex-shrink-0) - Always visible at bottom
```

### 🧪 Testing
- Verified dialog doesn't exceed viewport height
- Confirmed all form fields are accessible via scrolling
- Ensured header and footer remain visible and functional
- Tested on different screen sizes

### 📱 Responsive Design
- Works on both desktop and mobile viewports
- Maintains proper spacing and usability across screen sizes
- Scrollbar appears only when content exceeds available space

This fix ensures users can always access all form fields and the submit/cancel buttons, regardless of form length or screen size.