### PR TITLE
🔧 Fix 404 errors for Git Settings and LLM Settings navigation

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -102,6 +102,14 @@ export const router = createBrowserRouter([
             element: <LlmSettings />,
           },
           {
+            path: "llm",
+            element: <LlmSettings />,
+          },
+          {
+            path: "git",
+            element: <GitSettings />,
+          },
+          {
             path: "mcp",
             element: <McpSettings />,
           },
@@ -132,10 +140,6 @@ export const router = createBrowserRouter([
           {
             path: "api-keys",
             element: <ApiKeys />,
-          },
-          {
-            path: "webhooks",
-            element: <WebhookSettings />,
           },
         ],
       },


### PR DESCRIPTION
## 🐛 Problem
Users were encountering 404 errors when trying to access Git Settings and LLM Settings from the Account Settings page. The navigation links were pointing to routes that didn't exist in the router configuration.

### 🔍 Root Cause Analysis
- Navigation links in `profile.tsx` were pointing to `/settings/git` and `/settings/llm`
- Router configuration only had:
  - `/settings/integrations` for Git Settings (not `/settings/git`)
  - `/settings` (index route) for LLM Settings (not `/settings/llm`)
- There was also a duplicate webhook route causing potential routing conflicts

## ✅ Solution
Fixed the router configuration to match the navigation expectations:

### 🔧 Changes Made
1. **Added explicit routes**:
   - `/settings/git` → `GitSettings` component
   - `/settings/llm` → `LlmSettings` component

2. **Maintained backward compatibility**:
   - Kept `/settings/integrations` → `GitSettings` for any existing bookmarks/links
   - Kept `/settings` (index) → `LlmSettings` as default settings page

3. **Cleaned up routing conflicts**:
   - Removed duplicate webhook route that was defined twice

### 🧪 Testing
- Verified `/settings/git` now loads Git Settings page
- Verified `/settings/llm` now loads LLM Settings page  
- Confirmed backward compatibility with existing routes
- Tested navigation from Account Settings profile page

### 📋 Route Structure After Fix
```
/settings (index) → LLM Settings (default)
├── /settings/llm → LLM Settings (explicit)
├── /settings/git → Git Settings (explicit)
├── /settings/integrations → Git Settings (backward compatibility)
├── /settings/user → User Settings
├── /settings/app → App Settings
├── /settings/secrets → Secrets Settings
├── /settings/webhooks → Webhook Settings
└── /settings/api-keys → API Keys Settings
```

This fix ensures users can successfully navigate to all settings pages from the Account Settings interface without encountering 404 errors.