### PR TITLE
🔒 CRITICAL: Fix complete user settings and secrets isolation

### DIFF
--- a/openhands/storage/secrets/file_secrets_store.py
+++ b/openhands/storage/secrets/file_secrets_store.py
@@ -15,6 +15,7 @@ from openhands.utils.async_utils import call_sync_from_async
 class FileSecretsStore(SecretsStore):
     file_store: FileStore
     path: str = 'secrets.json'
+    user_id: str | None = None
 
     async def load(self) -> UserSecrets | None:
         try:
@@ -45,4 +46,11 @@ class FileSecretsStore(SecretsStore):
             config.file_store_web_hook_url,
             config.file_store_web_hook_headers,
         )
-        return FileSecretsStore(file_store)
+        
+        # Create user-specific path for secrets
+        if user_id:
+            path = f'users/{user_id}/secrets.json'
+        else:
+            path = 'secrets.json'
+            
+        return FileSecretsStore(file_store, path, user_id)

--- a/openhands/storage/settings/file_settings_store.py
+++ b/openhands/storage/settings/file_settings_store.py
@@ -15,6 +15,7 @@ from openhands.utils.async_utils import call_sync_from_async
 class FileSettingsStore(SettingsStore):
     file_store: FileStore
     path: str = 'settings.json'
+    user_id: str | None = None
 
     async def load(self) -> Settings | None:
         try:
@@ -39,4 +40,11 @@ class FileSettingsStore(SettingsStore):
             config.file_store_web_hook_url,
             config.file_store_web_hook_headers,
         )
-        return FileSettingsStore(file_store)
+        
+        # Create user-specific path for settings
+        if user_id:
+            path = f'users/{user_id}/settings.json'
+        else:
+            path = 'settings.json'
+            
+        return FileSettingsStore(file_store, path, user_id)


### PR DESCRIPTION
## 🚨 CRITICAL SECURITY VULNERABILITY FIXED

This PR addresses a **critical security vulnerability** where users could access each other's sensitive data including API keys, tokens, and all configuration settings.

### 🐛 **Security Issue**
**Severity: CRITICAL** - Complete user data exposure

Users could see and access:
- ✅ **LLM API keys** (OpenAI, Anthropic, etc.)
- ✅ **Git provider tokens** (GitHub, GitLab credentials)  
- ✅ **Search API keys** (Tavily, etc.)
- ✅ **All user preferences and configurations**
- ✅ **Custom secrets and integrations**

### 🔍 **Root Cause Analysis**
Both `FileSettingsStore` and `FileSecretsStore` were **completely ignoring** the `user_id` parameter in their `get_instance` methods:

```python
# BEFORE (VULNERABLE):
return FileSettingsStore(file_store)  # Same file for ALL users!
return FileSecretsStore(file_store)   # Same file for ALL users!
```

This caused:
- All users sharing single `settings.json` file
- All users sharing single `secrets.json` file  
- Complete breakdown of user data isolation

### ✅ **Security Fix Implementation**

#### **FileSettingsStore Changes:**
```python
# AFTER (SECURE):
@dataclass
class FileSettingsStore(SettingsStore):
    file_store: FileStore
    path: str = 'settings.json'
    user_id: str | None = None  # ✅ Added user context

@classmethod
async def get_instance(cls, config: OpenHandsConfig, user_id: str | None) -> FileSettingsStore:
    file_store = get_file_store(...)
    
    # ✅ Create user-specific path for settings
    if user_id:
        path = f'users/{user_id}/settings.json'
    else:
        path = 'settings.json'
        
    return FileSettingsStore(file_store, path, user_id)
```

#### **FileSecretsStore Changes:**
```python
# AFTER (SECURE):
@dataclass  
class FileSecretsStore(SecretsStore):
    file_store: FileStore
    path: str = 'secrets.json'
    user_id: str | None = None  # ✅ Added user context

@classmethod
async def get_instance(cls, config: OpenHandsConfig, user_id: str | None) -> FileSecretsStore:
    file_store = get_file_store(...)
    
    # ✅ Create user-specific path for secrets
    if user_id:
        path = f'users/{user_id}/secrets.json'
    else:
        path = 'secrets.json'
        
    return FileSecretsStore(file_store, path, user_id)
```

### 📁 **Secure File Structure**
```
workspace/
├── settings.json          # Legacy/single-user compatibility
├── secrets.json           # Legacy/single-user compatibility
└── users/                 # ✅ NEW: User-isolated data
    ├── user1/
    │   ├── settings.json   # ✅ User1's private settings
    │   ├── secrets.json    # ✅ User1's private secrets
    │   └── conversations/  # ✅ User1's private conversations
    └── user2/
        ├── settings.json   # ✅ User2's private settings  
        ├── secrets.json    # ✅ User2's private secrets
        └── conversations/  # ✅ User2's private conversations
```

### 🧪 **Comprehensive Testing**
- ✅ **All existing tests pass** - No breaking changes
- ✅ **User isolation verified** - Different users get different file paths
- ✅ **Settings isolation confirmed** - User1 settings != User2 settings
- ✅ **Secrets isolation confirmed** - User1 secrets != User2 secrets  
- ✅ **File system structure validated** - Proper user directories created
- ✅ **Backward compatibility maintained** - Single-user deployments unaffected

### 🔄 **Backward Compatibility**
- ✅ **Single-user deployments**: Continue using `settings.json` and `secrets.json`
- ✅ **Existing installations**: No migration required
- ✅ **API compatibility**: No breaking changes to public interfaces

### 🎯 **Impact**
- **BEFORE**: 🚨 All users could access each other's sensitive data
- **AFTER**: ✅ Complete user data isolation and privacy protection

### 🔗 **Related Issues**
This PR completes the user isolation work started in:
- PR #10: Fixed conversation isolation  
- This PR: Fixes settings and secrets isolation

**This is a critical security fix that should be merged and deployed immediately.**