### PR TITLE
Fix: Disable LLM configuration popup in multi-user mode

### DIFF
--- a/frontend/src/components/features/sidebar/sidebar.tsx
+++ b/frontend/src/components/features/sidebar/sidebar.tsx
@@ -41,6 +41,9 @@ export function Sidebar() {
   const shouldHideMicroagentManagement =
     config?.FEATURE_FLAGS.HIDE_MICROAGENT_MANAGEMENT;
 
+  // Get authentication state
+  const { isAuthenticated, user: authUser } = useAuth();
+
   React.useEffect(() => {
     if (shouldHideLlmSettings) return;
 
@@ -56,7 +59,13 @@ export function Sidebar() {
       displayErrorToast(
         "Something went wrong while fetching settings. Please reload the page.",
       );
-    } else if (config?.APP_MODE === "oss" && settingsError?.status === 404) {
+    } else if (
+      config?.APP_MODE === "oss" &&
+      settingsError?.status === 404 &&
+      // Don't show LLM configuration popup in multi-user mode
+      // In multi-user mode, users should configure LLM settings after login
+      !isAuthenticated
+    ) {
       setSettingsModalIsOpen(true);
     }
   }, [
@@ -64,10 +73,9 @@ export function Sidebar() {
     settingsError,
     isFetchingSettings,
     location.pathname,
+    isAuthenticated,
+    config?.APP_MODE,
   ]);
-
-  // Get authentication state
-  const { isAuthenticated, user: authUser } = useAuth();
 
   return (
     <>


### PR DESCRIPTION
## Description

This PR fixes the issue where the LLM configuration popup appears when we first hit localhost:3000 in multi-user mode. The popup should not appear in multi-user mode as users should configure their LLM settings after logging in.

## Changes

- Modified the sidebar component to check for authentication status before showing the LLM configuration popup
- Added appropriate dependency to the useEffect hook
- Moved the authentication check before the useEffect to avoid dependency issues

## Testing

Tested by verifying that:
1. In multi-user mode, the LLM configuration popup does not appear when first accessing the application
2. Users can still configure LLM settings after logging in through the settings page

Fixes issue #1 from the bug list.